### PR TITLE
feat: make grepFilterSpecs work with negative grep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,12 +111,43 @@ jobs:
             --env grep="hello; works 2" \
             --expect ./expects/hello-or-works-2.json
 
+      # grepFilterSpecs tests
+
+      - name: filter the specs first with grep 🧪
+        run: |
+          npx cypress-expect \
+            --config specPattern="**/*.js" \
+            --env grep="outside any suites",grepFilterSpecs=true \
+            --expect-exactly expects/grep-filter-specs.json
+
+      - name: filter the specs first with grepTags 🧪
+        run: |
+          npx cypress-expect \
+            --config specPattern="cypress/integration/**/*.js" \
+            --env grepTags=@smoke,grepFilterSpecs=true \
+            --expect-exactly expects/grep-filter-specs-tag.json
+
+      # https://github.com/cypress-io/cypress-grep/issues/98
+      - name: Tags OR specs with grepFilterSpecs=true 🧪
+        run: |
+          npx cypress-expect \
+            --config specPattern="**/tags/*.spec.js" \
+            --env grepTags="high regression",grepFilterSpecs=true \
+            --expect-exactly expects/tags-or-filter.json
+
       # https://github.com/cypress-io/cypress-grep/issues/96
       - name: Run tests with "hello" or "works 2" with spec filtering 🧪
         run: |
           npx cypress-expect run \
             --env grep="hello; works 2",grepFilterSpecs=true \
             --expect ./expects/hello-or-works-2.json
+
+      - name: filter multiple specs with negative grep and grepFilterSpecs=true 🧪
+        run: |
+          npx cypress-expect run \
+            --env grep=-hello,grepFilterSpecs=true \
+            --config specPattern="cypress/integration/{spec,negative-grep-spec}.js" \
+            --expect-exactly ./expects/no-hello.json
 
   tests2:
     runs-on: ubuntu-20.04
@@ -233,14 +264,6 @@ jobs:
             --config specPattern="**/tags/*.spec.js" \
             --env grepTags="high+smoke" \
             --expect-exactly expects/tags-and.json
-
-      # https://github.com/cypress-io/cypress-grep/issues/98
-      - name: Tags OR specs with grepFilterSpecs=true 🧪
-        run: |
-          npx cypress-expect \
-            --config specPattern="**/tags/*.spec.js" \
-            --env grepTags="high regression",grepFilterSpecs=true \
-            --expect-exactly expects/tags-or-filter.json
 
       - name: Specify is an alias to it 🧪
         run: |
@@ -361,20 +384,6 @@ jobs:
             --config specPattern="**/this-spec.js" \
             --env burn=3 \
             --expect expects/this-spec.json
-
-      - name: filter the specs first 🧪
-        run: |
-          npx cypress-expect \
-            --config specPattern="**/*.js" \
-            --env grep="outside any suites",grepFilterSpecs=true \
-            --expect-exactly expects/grep-filter-specs.json
-
-      - name: filter the specs first by tag 🧪
-        run: |
-          npx cypress-expect \
-            --config specPattern="cypress/integration/**/*.js" \
-            --env grepTags=@smoke,grepFilterSpecs=true \
-            --expect-exactly expects/grep-filter-specs-tag.json
 
       - name: run untagged tests 🧪
         run: |

--- a/cypress/integration/negative-grep-spec.js
+++ b/cypress/integration/negative-grep-spec.js
@@ -1,0 +1,5 @@
+/// <reference types="cypress" />
+
+describe('hello', () => {
+  it('world', () => {})
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "debug": "4.3.1",
-        "find-test-names": "^1.17.2",
+        "find-test-names": "^1.18.0",
         "globby": "^11.0.4"
       },
       "devDependencies": {
@@ -1952,9 +1952,9 @@
       }
     },
     "node_modules/find-test-names": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.17.2.tgz",
-      "integrity": "sha512-M33rSgOzGK6014CYghvuX5rTeI7tTXBSo5nn6/XRNP9Wc2v2c+ViQtFDu4U2nz3TPw0EZBtC8fpCIwFYAfC4fA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.18.0.tgz",
+      "integrity": "sha512-Ci4fD1j41OdGg9EHRwNmueeOLms3yWu/okTj/94Sd67grFmcwVxRCRgNHtiP82X0M2H8CCm/BptgTmQhANjw0w==",
       "dependencies": {
         "@babel/parser": "^7.16.5",
         "acorn-walk": "^8.2.0",
@@ -9167,9 +9167,9 @@
       }
     },
     "find-test-names": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.17.2.tgz",
-      "integrity": "sha512-M33rSgOzGK6014CYghvuX5rTeI7tTXBSo5nn6/XRNP9Wc2v2c+ViQtFDu4U2nz3TPw0EZBtC8fpCIwFYAfC4fA==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/find-test-names/-/find-test-names-1.18.0.tgz",
+      "integrity": "sha512-Ci4fD1j41OdGg9EHRwNmueeOLms3yWu/okTj/94Sd67grFmcwVxRCRgNHtiP82X0M2H8CCm/BptgTmQhANjw0w==",
       "requires": {
         "@babel/parser": "^7.16.5",
         "acorn-walk": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "debug": "4.3.1",
-    "find-test-names": "^1.17.2",
+    "find-test-names": "^1.18.0",
     "globby": "^11.0.4"
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -74,12 +74,12 @@ function cypressGrepPlugin(config) {
       greppedSpecs = specFiles.filter((specFile) => {
         const text = fs.readFileSync(specFile, { encoding: 'utf8' })
         try {
-          const names = getTestNames(text)
-          const testAndSuiteNames = names.suiteNames.concat(names.testNames)
+          const result = getTestNames(text, true)
+          const testNames = result.fullTestNames
           debug('spec file %s', specFile)
-          debug('suite and test names: %o', testAndSuiteNames)
+          debug('full test names: %o', testNames)
 
-          return testAndSuiteNames.some((name) => {
+          return testNames.some((name) => {
             const shouldRun = shouldTestRun(parsedGrep, name)
             return shouldRun
           })


### PR DESCRIPTION
I think this will fix another bug that occurs when using only negative tags.

--
The updated version of find-test-names outputs
full test names, i.e. prepended with the parent
suite names.
This allows grepFilterSpecs to filter
spec files when negative grep matches test but
not suite and vice versa.

Benefit:
The log is less cluttered, especially
with a lot of specs.
The speed improvement is minor,
about 1.5 seconds per filtered spec file.